### PR TITLE
updated go and github actions versions to see if it pass

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
-      - name: Install Go 1.18
-        uses: actions/setup-go@v2
+      - name: Install Go 1.21.x
+        uses: actions/setup-go@v4
         with:
-          go-version: '1.18'
+          go-version: "1.21.x"
 
       - name: Go modules cache
         uses: actions/cache@v1


### PR DESCRIPTION
updated go and github actions versions to see if it pass, related to this PR: https://github.com/knative-extensions/eventing-autoscaler-keda/pull/380